### PR TITLE
Add Playwright E2E test for Parquet upload

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -11,5 +11,5 @@ jobs:
         with:
           python-version: '3.11'
       - run: pip install -r requirements.txt
-      - run: pip install -r requirements.txt
+      - run: playwright install --with-deps
       - run: pytest -q

--- a/README.md
+++ b/README.md
@@ -67,5 +67,18 @@ The CLI will invoke MultiModalTransformer when it’s installed, echoing a
 JSON blob that lists both input and output tensor shapes so you can verify
 live inference end-to-end.
 
+### End-to-End browser test
+
+When a local dev server is running (`OMNI_UI_URL=http://localhost:3000`),
+Playwright will upload a tiny Parquet sample, wait for inference, and assert
+that the JSON payload contains the expected tensor shapes:
+
+```bash
+export OMNI_UI_URL=http://localhost:3000
+pytest -k e2e
+```
+
+CI skips this test automatically when OMNI_UI_URL is not set.
+
 ---
 © 2025 OmniIntent XR Team

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ pandas>=2.2
 pyarrow>=15.0         # fast parquet/CSV parsing for Quest 3 logs
 torch>=2.1            # tensor operations
 typer>=0.9            # ergonomic CLI utilities
+playwright>=1.45      # browser automation for E2E upload test
+pytest-playwright>=0.5  # pytest plugin

--- a/tests/e2e/test_upload_parquet.py
+++ b/tests/e2e/test_upload_parquet.py
@@ -1,0 +1,45 @@
+"""
+E2E browser test: uploads a tiny Quest 3 Parquet log and checks JSON inference
+output.  Skips automatically when `OMNI_UI_URL` is undefined (e.g. headless CI).
+"""
+import os, json, numpy as np, pandas as pd, pytest
+from playwright.sync_api import sync_playwright
+
+@pytest.mark.skipif(
+    "OMNI_UI_URL" not in os.environ, reason="UI server URL not provided"
+)
+def test_upload_parquet(tmp_path):
+    # --- craft a 10‑frame Parquet file on‑the‑fly -------------------------
+    df = pd.DataFrame(
+        [
+            {
+                "timestamp_ns": i * 8_333_333,
+                "left_gaze_yaw": np.random.rand(),
+                "left_gaze_pitch": np.random.rand(),
+                "fix_conf": 0.8,
+                "hand_pose_0_x": np.random.rand(),
+            }
+            for i in range(10)
+        ]
+    )
+    parquet = tmp_path / "tiny.parquet"
+    df.to_parquet(parquet, index=False)
+
+    # --- drive the UI -----------------------------------------------------
+    ui_url = os.environ["OMNI_UI_URL"]
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        page.goto(ui_url)
+
+        # upload file
+        page.set_input_files('input[type="file"]', str(parquet))
+
+        # wait for JSON blob with tensor shapes
+        page.wait_for_selector("#inference-json")
+        payload = json.loads(page.inner_text("#inference-json"))
+
+        # basic sanity checks
+        assert payload["input_shapes"]["gaze"][-1] == 3      # feature-dim
+        assert payload["input_shapes"]["hand_pose"][-1] == 1 # feature-dim
+        browser.close()


### PR DESCRIPTION
## Summary
- test: add Playwright E2E that uploads Parquet and checks JSON
- install browsers in CI
- document end-to-end browser test in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853c803d550832d9d3fc68fac442051