### PR TITLE
Add Quest3Dataset loader and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,22 @@ The CLI will invoke MultiModalTransformer when it’s installed, echoing a
 JSON blob that lists both input and output tensor shapes so you can verify
 live inference end-to-end.
 
+### Training & fine-tuning datasets
+
+Need a PyTorch-native stream of fixed-length Quest 3 windows?  Use
+`Quest3Dataset`:
+
+```python
+from omniintent.ingest import Quest3Dataset
+from torch.utils.data import DataLoader
+
+ds = Quest3Dataset("my_logs/", seq_len=60, stride=30)
+loader = DataLoader(ds, batch_size=8, shuffle=True)
+for batch in loader:
+    # batch["gaze"].shape → (8, 60, 3)
+    ...
+```
+
 ### End-to-End browser test
 
 When a local dev server is running (`OMNI_UI_URL=http://localhost:3000`),

--- a/src/omniintent/ingest/__init__.py
+++ b/src/omniintent/ingest/__init__.py
@@ -1,0 +1,12 @@
+"""
+omniintent.ingest package
+=========================
+Convenience re-exports so callers can do:
+
+    from omniintent.ingest import Quest3Dataset, load_quest3
+"""
+
+from .quest3_ingest import load as load_quest3  # noqa: F401
+from .quest3_dataset import Quest3Dataset  # noqa: F401
+
+__all__ = ["Quest3Dataset", "load_quest3"]

--- a/src/omniintent/ingest/quest3_dataset.py
+++ b/src/omniintent/ingest/quest3_dataset.py
@@ -1,0 +1,88 @@
+"""
+quest3_dataset.py
+~~~~~~~~~~~~~~~~~
+PyTorch `Dataset` that turns a folder (or list) of Quest\u00a03 CSV/Parquet logs
+into fixed-length, optionally-overlapping windows of multimodal tensors.
+
+Example
+-------
+>>> ds = Quest3Dataset("logs/", seq_len=60, stride=30)
+>>> batch = torch.utils.data.DataLoader(ds, batch_size=8, shuffle=True)
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable, Iterable, List, Sequence, Union
+
+import torch
+from torch.utils.data import Dataset
+
+from .quest3_ingest import load as _load_q3
+
+
+class Quest3Dataset(Dataset):  # type: ignore[misc]
+    """Create sliding windows over Quest\u00a03 sensor logs."""
+
+    def __init__(
+        self,
+        files: Union[str, Path, Sequence[Union[str, Path]]],
+        seq_len: int = 60,
+        stride: int | None = None,
+        transform: Callable[[dict[str, torch.Tensor]], dict[str, torch.Tensor]]
+        | None = None,
+    ):
+        """
+        Parameters
+        ----------
+        files
+            Directory or list/tuple of CSV/Parquet paths.
+        seq_len
+            Frames per sample.
+        stride
+            Overlap between windows.  Defaults to `seq_len` (no overlap).
+        transform
+            Optional function applied to **each** tensor dict before return.
+        """
+        self.seq_len = seq_len
+        self.stride = stride or seq_len
+        self.transform = transform
+
+        # Expand directory into file list
+        if isinstance(files, (str, Path)) and Path(files).is_dir():
+            self.files: List[Path] = sorted(
+                p for p in Path(files).glob("*") if p.suffix in {".csv", ".parquet"}
+            )
+        else:
+            self.files = [Path(f) for f in files]  # type: ignore[arg-type]
+
+        # Pre-compute offsets: (file_idx, start_frame)
+        self.index: list[tuple[int, int]] = []
+        for f_idx, path in enumerate(self.files):
+            # Use loader to infer total frames
+            batch = _load_q3(str(path), seq_len=10_000)  # big number \u2192 full file
+            # any modal shape is fine (batch=1, frames, feat)
+            num_frames = next(iter(batch.values())).shape[1]
+            for start in range(0, num_frames - seq_len + 1, self.stride):
+                self.index.append((f_idx, start))
+
+    # --------------------------------------------------------------------- #
+    def __len__(self) -> int:  # noqa: D401
+        """Return number of sliding windows across all logs."""
+        return len(self.index)
+
+    def __getitem__(self, idx: int) -> dict[str, torch.Tensor]:
+        f_idx, start = self.index[idx]
+        file_path = self.files[f_idx]
+        batch = _load_q3(str(file_path), seq_len=start + self.seq_len)
+
+        # cut window & squeeze batch-dim
+        window = {
+            k: v[0, start : start + self.seq_len] for k, v in batch.items()
+        }
+
+        if self.transform:
+            window = self.transform(window)
+        return window
+
+
+__all__ = ["Quest3Dataset"]

--- a/tests/test_quest3_dataset.py
+++ b/tests/test_quest3_dataset.py
@@ -1,0 +1,50 @@
+import numpy as np, pandas as pd, torch
+from omniintent.ingest.quest3_dataset import Quest3Dataset
+
+
+def _make_csv(path, frames=120):
+    rows = [
+        {
+            "timestamp_ns": i * 8_333_333,
+            "left_gaze_yaw": np.random.rand(),
+            "left_gaze_pitch": np.random.rand(),
+            "fix_conf": 0.8,
+            "hand_pose_0_x": np.random.rand(),
+        }
+        for i in range(frames)
+    ]
+    pd.DataFrame(rows).to_csv(path, index=False)
+
+
+def test_dataset_len_and_shapes(tmp_path):
+    # two logs, 120 frames each \u2192 with seq_len=60, stride=30:
+    # windows per file: 0,30,60 \u2192 3 windows \u00d7 2 files = 6 samples
+    paths = []
+    for n in range(2):
+        p = tmp_path / f"log{n}.csv"
+        _make_csv(p, frames=120)
+        paths.append(p)
+
+    ds = Quest3Dataset(paths, seq_len=60, stride=30)
+
+    assert len(ds) == 6
+
+    sample = ds[0]
+    assert sample["gaze"].shape == (60, 3)
+    assert sample["hand_pose"].shape == (60, 1)
+    # Enforce Tensor dtype
+    assert isinstance(sample["gaze"], torch.Tensor)
+
+
+def test_dataset_transform(tmp_path):
+    p = tmp_path / "log.csv"
+    _make_csv(p, frames=60)
+
+    def add_norm(batch):
+        batch["norm"] = torch.norm(batch["gaze"], dim=-1, keepdim=True)
+        return batch
+
+    ds = Quest3Dataset([p], seq_len=60, transform=add_norm)
+    sample = ds[0]
+    assert "norm" in sample
+    assert sample["norm"].shape == (60, 1)


### PR DESCRIPTION
## Summary
- add `Quest3Dataset` for sliding window batching of Quest 3 logs
- re-export in `omniintent.ingest` package
- document dataset usage in README
- add unit tests for dataset

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853cc2754a8832d94e31beb7cc9f94b